### PR TITLE
Change the privacy module tracking branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "altis/enhanced-search": "dev-master",
     "altis/documentation": "dev-master",
     "altis/media": "dev-master",
-    "altis/privacy": "dev-main",
+    "altis/privacy": "dev-master",
     "altis/seo": "dev-master",
     "altis/sso": "dev-master",
     "altis/security": "dev-master",


### PR DESCRIPTION
Until we switch all the default branches over we need to keep this consistent to ensure the latest version.