### PR TITLE
Bump PHP requirement to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "altis/core": "dev-master",
     "altis/cms": "dev-master",
     "altis/cloud": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.0",
     "altis/core": "dev-master",
     "altis/cms": "dev-master",
     "altis/cloud": "dev-master",


### PR DESCRIPTION
Altis v12 is deprecating PHP 7.4. 8.0 is now the recommended version of PHP, 7.4 is still supported, anything below that is no longer supported.

Compatibility chart: https://docs.altis-dxp.com/guides/updating-php/#altis-compatibility-chart