### PR TITLE
Remove the new module until it is public.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
 	],
 	"require": {
 		"php": ">=8.1",
-		"altis/advanced-security": "dev-master",
 		"altis/core": "dev-master",
 		"altis/cms": "dev-master",
 		"altis/cloud": "dev-master",


### PR DESCRIPTION
We don't need to try to pull the module while it is not public, it just breaks things.
