### PR TITLE
Update the minimum PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.1",
+		"php": ">=8.2",
 		"altis/core": "dev-master",
 		"altis/cms": "dev-master",
 		"altis/cloud": "dev-master",


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: humanmade/product-dev#1735